### PR TITLE
Fix: Removed Path Restrictions On API Pipeline

### DIFF
--- a/pipelines/azure-pipelines-api-cicd.yml
+++ b/pipelines/azure-pipelines-api-cicd.yml
@@ -2,15 +2,6 @@ trigger:
   branches:
    include:
      - main
-  paths:
-    include:
-      - dertinfo-api
-      - dertinfo-api.utests
-      - dertinfo-models
-      - dertinfo-services
-      - dertinfo-services.utests
-      - dertinfo-repository
-      - dertinfo-repository.utests
 
 variables:
   buildConfiguration: 'Release'


### PR DESCRIPTION
## Description

Previous PR to main didn't trigger pipeline. I expect that it's because we've move the pipeline file and the paths are different. However we didn't need the restriction as we're no longer running a Mono repo.

Fixes # (issue)

Teething Issues when splitting project and migrating to opensource. 

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It has not been tested as we need to use the deployment to test it

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules