### PR TITLE
Address Secrets Override In Docker Compose Project

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -14,13 +14,13 @@ services:
       - SqlConnection:ServerAdminName=sa
       - SqlConnection:DatabaseName=DertInfoDb
       - SendGrid:Enabled=false
-      - SendGrid:ApiKey=[notRequiredAsEmailsDisabled] # This will need to be populated if you want to test email send functionality. See README.md
-      - Auth0:ManagementClientSecret=[theApiWillNeedThisValueToAuthoriseRequests] # This will need to be populated to allow the api to validate requests. See README.md
       - Auth0:Domain=dertinfodev.eu.auth0.com
       - StorageAccount:Images:Protocol=http
       - StorageAccount:Images:Name=devstoreaccount1
       - StorageAccount:Images:Key=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw== # Azurite Key Available Publically
       - StorageAccount:Images:BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1 #  Running in docker
+      # [VS: Do Not Override Secrets With Envionment Vars For This Setting] - Auth0:ManagementClientSecret=[theApiWillNeedThisValueToAuthoriseRequests]
+      # [VS: Do Not Override Secrets With Envionment Vars For This Setting] - SendGrid:ApiKey=[notRequiredAsEmailsDisabled]
     build:
       context: .
       dockerfile: dertinfo-api/Dockerfile


### PR DESCRIPTION
## Description

Removed SendGrid, Auth0 settings from docker-compose.yml to Allow secrets to pull through.
Comments added to prevent overriding secrets in the future

Fixes #19 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We have  validated following a secrets rotation that the full estate continues to work running from docker compose. 

It was the rotation of secrets that brought the issue to our attention

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules