### PR TITLE
[Fix] Fix the sortorder For Dance results score category in web project to match collated.

### DIFF
--- a/src/dertinfo-models/Database/Dance.cs
+++ b/src/dertinfo-models/Database/Dance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DertInfo.Models.Database
 {
@@ -28,6 +29,13 @@ namespace DertInfo.Models.Database
         public virtual Competition Competition { get; set; }
         public virtual TeamAttendance TeamAttendance { get; set; }
         public virtual Venue Venue { get; set; }
+
+
+        public void OrderScoresByScoreCategory()
+        {
+            var scores = this.DanceScores.OrderBy(s => s.ScoreCategory.SortOrder).ToList();
+            this.DanceScores = scores;
+        }
 
     }
 }

--- a/src/dertinfo-services/Entity/Dances/DanceService.cs
+++ b/src/dertinfo-services/Entity/Dances/DanceService.cs
@@ -291,7 +291,17 @@ namespace DertInfo.Services.Entity.Dances
 
         public async Task<IEnumerable<Dance>> ListForCompetition(int competitionId)
         {
-            return await _danceRepository.GetDancesExpandedByCompetitionId(competitionId);
+            var dances = await _danceRepository.GetDancesExpandedByCompetitionId(competitionId);
+
+            foreach (var dance in dances)
+            {
+                dance.OrderScoresByScoreCategory();
+            }
+            // note - we use this here to ensure that when the client renders the results then the categories appear in the right order
+            //      - this is so that it matches the order of the collated results. We could do this on the client and
+            //      - probably should however for now due to ease it can be done here more quickly. Cemmenting for dept tracking
+
+            return dances;
         }
 
         public async Task UpdateCheckedState(int danceId, bool hasScoredChecked)


### PR DESCRIPTION
## Description

Order the scores within the dance list response so that they are congruent with the collated sores column order.

It addresses the problem raised in the DertInfo-web project here: https://github.com/dertinfo/dertinfo-web/issues/21

Fixes #dertinfo-web 21 (issue)

The web project should likely deal with this issue directly but this is the shortest path to a functioning solution for dert2025 . 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We have validated that this change does address the sort order problem and appears to only affect this API call so isexpected to be isolated. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 
### :bulb: PR Summary generated by FirstMate

**Overview**: Fixed the sort order for Dance results by implementing a method to order scores.

**Changes**:
*Score Ordering Logic:*
- Added `OrderScoresByScoreCategory` method in `Dance.cs` to sort scores by `ScoreCategory.SortOrder`.
- Updated `ListForCompetition` method in `DanceService.cs` to call the new sorting method for each dance.

**Documentation:**
- Added comments in `ListForCompetition` to clarify the purpose of the sorting logic.

**TLDR**: Implemented score ordering for Dance results to match collated results; focus on the new sorting method in `Dance.cs` and its integration in `DanceService.cs`.

<sub><sup>Generated by FirstMate and automatically updated on every commit.</sup></sub>