### PR TITLE
[Fix] Ensure that the collated dance scores in the event admin display in thier defined sort order

### DIFF
--- a/src/dertinfo-api/Controllers/ResultsAuthController.cs
+++ b/src/dertinfo-api/Controllers/ResultsAuthController.cs
@@ -81,7 +81,7 @@ namespace DertInfo.Api.Controllers
 
                 List<ScoreGroup> scoreGroups = new List<ScoreGroup>();
 
-                foreach (var scoreCategory in myCompetition.ScoreCategories)
+                foreach (var scoreCategory in myCompetition.ScoreCategories.OrderBy(sc => sc.SortOrder))
                 {
                     scoreGroups.Add(new ScoreGroup
                     {


### PR DESCRIPTION

## Description

Order the score categories in the collated results to ensure that thy are presented to the front end in the correct sort order by their sort order property.

This is in order that the score categories present in the same order for dances and collated. This allows for cleaner export of the csv and subsequently working with the data once downloaded from the client. 

It is noted that the CSV export is from the client data only and not from the API. 

Fixes #26  (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

At this point these changes have been validated locally and will be checked on staging once the PR  has been accepted. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 
### :bulb: PR Summary generated by FirstMate

**Overview**: Fixed the sorting of collated dance scores in the event admin.

**Changes**:
*Sorting Logic Update:*
- Modified the loop in `ResultsAuthController.cs` to order `ScoreCategories` by `SortOrder`.
- This ensures that dance scores are displayed in the defined sort order.

**TLDR**: The sorting of dance scores in the event admin is now based on the defined `SortOrder`. Focus on the changes in `ResultsAuthController.cs`.

<sub><sup>Generated by FirstMate and automatically updated on every commit.</sup></sub>