### PR TITLE
Implement specific CORS policy to limits allowed origins for the API

### DIFF
--- a/src/dertinfo-api/Startup.cs
+++ b/src/dertinfo-api/Startup.cs
@@ -26,7 +26,6 @@ namespace DertInfo.Api
             Configuration = configuration;
             Environment = env;
 
-
             var imagesStorageAccount = $"https://{Configuration["StorageAccount:Images:Name"]}.blob.core.windows.net";
             if (env.IsDevelopment())
             {
@@ -94,7 +93,12 @@ namespace DertInfo.Api
 
                 if (allowedCorsOriginsArray.Length == 0 || string.IsNullOrEmpty(allowedCorsOriginsArray.First()))
                 {
-                    throw new Exception("AllowedOrigins is not set in the configuration file.");
+                    throw new Exception("AllowedOrigins configuration is not set");
+                }
+
+                if (allowedCorsOriginsArray.Any(origin => !Uri.IsWellFormedUriString(origin, UriKind.Absolute)))
+                {
+                    throw new Exception("One or more AllowedOrigins are not valid URLs.");
                 }
 
                 options.AddPolicy("AllowSpecificOrigins",
@@ -123,7 +127,6 @@ namespace DertInfo.Api
             // AutoMapper
             services.AddSingleton<IMapper>(sp => _mapperConfiguration.CreateMapper());
             services.AddApplicationInsightsTelemetry();
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/dertinfo-api/appsettings.json
+++ b/src/dertinfo-api/appsettings.json
@@ -14,6 +14,9 @@
     "480x360": "480",
     "100x100": "100"
   },
+  "Cors": {
+    "AllowedOrigins": "http://localhost:44200,http://localhost:44300"
+  },
   "AzureStorageAccount": {
     "StorageEnvionment": "Development",
     "MarkingSheetsStorageContainer": "dev-scoresheets",


### PR DESCRIPTION
## Description

Limits the Allowed Origins for the API

Implement specific CORS policy from appsettings.json
- Introduce new CORS policy configuration in `Startup.cs` to read allowed origins from `appsettings.json`.
- Add `Microsoft.IdentityModel.Tokens` namespace in `Startup.cs`.
- Replace `app.UseCors("AllowAll")` with `app.UseCors("AllowSpecificOrigins")`.
- Update `appsettings.json` with a new `Cors` section and `AllowedOrigins` key.

**IMPORTANT** - With the addition to the appconfiguration.json file we need to add these settings into the AzureAppConfiguration settings for test and Live with the correct values. 

(Label: Staging) Cors:AllowedOrigins - https://staging.dertinfo.co.uk, https://staging-app.dertinfo.co.uk
(Label: Production) Cors:AllowedOrigins - https://www.dertinfo.co.uk, https://app.dertinfo.co.uk

Fixes #30  (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have tested locally and validated that the CORS policy allows the web origin when it should and when running on a different port access is denied. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 
### :bulb: PR Summary generated by FirstMate

**CORS Policy Implementation:**
- Implemented a specific CORS policy to limit allowed origins for the API.

**Changes:**
*Startup Configuration:*
- Replaced "AllowAll" CORS policy with "AllowSpecificOrigins" to restrict origins.
- Added validation for allowed origins configuration in `Startup.cs`.
- Throws exceptions for empty or invalid URLs in allowed origins.

*Configuration Update:*
- Added "Cors" section in `appsettings.json` with allowed origins for local development.

**TLDR**: This PR implements a specific CORS policy to restrict allowed origins for the API, enhancing security. Review the changes in `Startup.cs` for policy implementation and `appsettings.json` for configuration details.

<sub><sup>Generated by FirstMate and automatically updated on every commit.</sup></sub>