### PR TITLE
Remove the tags from the openapi specification

### DIFF
--- a/src/dertinfo-api/Start/Swagger/AuthenticationFilter.cs
+++ b/src/dertinfo-api/Start/Swagger/AuthenticationFilter.cs
@@ -52,6 +52,9 @@ namespace DertInfo.Api.Start.Swagger
                 var generalRequirement = Swagger.SecuritySchemes.GetAuthenticationRequirement(generalScheme);
                 operation.Security.Add(generalRequirement);
             }
+
+            // Remove the tags that Swagger is adding to the definition
+            operation.Tags = new List<OpenApiTag>();
         }
     }
 }


### PR DESCRIPTION
## Description

This change removes the erroneous tags from the OpenAPI specification. They originally had the controller names as the tags which doesn't really provide any useful information. Removed to support the migration to APIM

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've tested locally and for such a small change this is enough

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules