### PR TITLE
Fix/20251208 fix publish pipeline

### DIFF
--- a/pipelines/azure-pipelines-api-cicd.yml
+++ b/pipelines/azure-pipelines-api-cicd.yml
@@ -24,7 +24,7 @@ stages:
   - job: 'Build'
     displayName: 'Build the API'
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'windows-latest'
       demands:
       - npm
 
@@ -47,7 +47,7 @@ stages:
       displayName: 'Build the project - $(buildConfiguration)'
       inputs:
         command: 'build'
-        arguments: '--no-restore --configuration $(buildConfiguration)'
+        arguments: '--no-restore --runtime win-x86 --configuration $(buildConfiguration)'
         projects: '**/dertinfo-api.csproj'
 
     - task: DotNetCoreCLI@2
@@ -56,7 +56,7 @@ stages:
         command: 'publish'
         projects: '**/dertinfo-api.csproj'
         publishWebProjects: false
-        arguments: '--no-build --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(buildConfiguration)'
+        arguments: '--no-build --runtime win-x86--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(buildConfiguration)'
         zipAfterPublish: true
 
     - publish: '$(Build.ArtifactStagingDirectory)'

--- a/pipelines/azure-pipelines-api-cicd.yml
+++ b/pipelines/azure-pipelines-api-cicd.yml
@@ -25,6 +25,7 @@ stages:
     displayName: 'Build the API'
     pool:
       vmImage: 'windows-latest'
+      # We should look to build on ubuntu and then deploy to Linux App Service in future
       demands:
       - npm
 
@@ -48,6 +49,7 @@ stages:
       inputs:
         command: 'build'
         arguments: '--no-restore --runtime win-x86 --configuration $(buildConfiguration)'
+        # We should look to target linux-x64 in future if Free and Shared App Service Support it
         projects: '**/dertinfo-api.csproj'
 
     - task: DotNetCoreCLI@2
@@ -56,7 +58,7 @@ stages:
         command: 'publish'
         projects: '**/dertinfo-api.csproj'
         publishWebProjects: false
-        arguments: '--no-build --runtime win-x86--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(buildConfiguration)'
+        arguments: '--no-build --runtime win-x86 --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(buildConfiguration)'
         zipAfterPublish: true
 
     - publish: '$(Build.ArtifactStagingDirectory)'

--- a/src/dertinfo-api/dertinfo-api.csproj
+++ b/src/dertinfo-api/dertinfo-api.csproj
@@ -13,6 +13,7 @@
     <UserSecretsId>bbbef35d-1f3c-4b15-a99a-c3e6818f6b81</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Staging|AnyCPU'" />
   <ItemGroup>


### PR DESCRIPTION
## Description

The application for a while was not building correctly for the Free and Shared Azure Web Apps as these are running windows VMs with x86. The pipeline as building for x64 which resulted in issues during deployment. 

Specifically when trying to switch to out-fo-process

HTTP Error 500.36 - ASP.NET Core IIS hosting failure (out-of-process)

We run In Process onthse VMs and if we want to switch to x64 running on Linux Out-Of-Process then we will do this as a seperate piece of work


Fixes #46 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Test A - I have deployed from the feature branch to staging and it works fine
- [X] Test B - I have tested the email capability that was being worked on when the pipeline failed

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules