### PR TITLE
Add configuration to allow running in a VSCode devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm
+
+# Remove the Yarn repository since we do not have the repository's GPG in the base image.
+# If we don't remove the repository, calls to `apt-get update` will fail, preventing
+# installation of any new packages, such as those installed by devcontainer features.
+RUN rm -f /etc/apt/sources.list.d/yarn.list && \
+    apt-get update

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+	"name": "DertInfo API (.NET 8)",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csharp",
+				"ms-dotnettools.csdevkit"
+			],
+			"settings": {
+				"dotnet.defaultSolution": "src/DertInfoApiSolution.sln"
+			}
+		}
+	},
+
+	"postCreateCommand": "dotnet restore src/DertInfoApiSolution.sln",
+
+	"remoteUser": "vscode"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,25 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md.
             "name": ".NET Core Launch (web)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/src/dertinfo-api/bin/Debug/net8.0/DertInfo.Api.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/dertinfo-api",
             "stopAtEntry": false,
-            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
-            "serverReadyAction": {
-                "action": "openExternally",
-                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
-            },
             "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "ASPNETCORE_HTTP_PORTS": "44100"
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md.
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/dertinfo-api/bin/Debug/net8.0/DertInfo.Api.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/dertinfo-api",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "files.autoSave": "afterDelay"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/DertInfoApiSolution.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/DertInfoApiSolution.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/src/DertInfoApiSolution.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Method 6) infra/docker> docker compose up
 Method 7 Step 1) Comment out the dertinfo-api service in infra/docker/docker-compose.yml
 Method 7 Step 2) docker compose up
 Method 7 Step 3) src/dertinfo-api> cat <path-to-json-file-containing-user-secrets> | dotnet user-secrets set
-Method 7 Step 4) Run '.NET Core Launch (web)'
+Method 7 Step 4) Run '.NET Core Launch (web)'. API will listen on port 44100.
 ```
 
 When using docker compose if any container fails to start just restart the container. In some cases we can get some timing issues that we should resolve using health checks. 

--- a/README.md
+++ b/README.md
@@ -34,21 +34,31 @@ In order to get this project running locally you are going to need.
 - Visual Studio Community
 - Microsoft SQL Server Express
 
+Experimental: Alternatively, you can use Visual Studio Code running in a devcontainer, with SQL Server running in docker.
 
 ## Running The Project
 
-You can run the API locally in 3 ways. 
+You can run the API locally in 7 ways. 
 - 1) (Visual Studio) Running as a isolated web app
 - 2) (Visual Studio) Running as a container in docker desktop 
-- 3) (Visual Studio) Running the docker componse project - This will spin up the entire estate using images on docker hub for the other parts. 
+- 3) (Visual Studio) Running the docker compose project - This will spin up the entire estate using images on docker hub for the other parts. 
 - 4) (Docker) Run the image using docker hub image
 - 5) (Docker) Build and Run using the Dockerfile
 - 6) (Docker Compose) Running the docker componse project (/infra/docker)  THis will spin up the API and all resoruces it depends on. 
+- 7) (Visual Studio Code) Running in a devcontainer with supporting components running from the docker compose project
 
+Steps for the above run methods:
 ```
-4) > docker run dertinfo/dertinfo-api:latest 
-5) src> docker build -t dertinfo/dertinfo-api -f dertinfo-api/Dockerfile .
-6) infra/docker> docker-compose up 
+Method 4) > docker run dertinfo/dertinfo-api:latest 
+
+Method 5) src> docker build -t dertinfo/dertinfo-api -f dertinfo-api/Dockerfile .
+
+Method 6) infra/docker> docker compose up 
+
+Method 7 Step 1) Comment out the dertinfo-api service in infra/docker/docker-compose.yml
+Method 7 Step 2) docker compose up
+Method 7 Step 3) src/dertinfo-api> cat <path-to-json-file-containing-user-secrets> | dotnet user-secrets set
+Method 7 Step 4) Run '.NET Core Launch (web)'
 ```
 
 When using docker compose if any container fails to start just restart the container. In some cases we can get some timing issues that we should resolve using health checks. 

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8' # Docker Compose file version
 
 services:
   # Service for the Dertinfo API
+  # Comment out this service is running the API locally, but you still want to run the other services in docker.
   dertinfo-api:
     container_name: api
     image: dertinfo/dertinfo-api
@@ -70,8 +71,8 @@ services:
      - AzureWebJobs.ResizeEventImages.Disabled=true
      - AzureWebJobs.ResizeGroupImages.Disabled=true
      - AzureWebJobs.ResizeSheetImages.Disabled=true
-     - AzureWebJobsStorage=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1;QueueEndpoint=http://host.docker.internal:10001/devstoreaccount1; # Azurite Connection Available Publically
-     - StorageConnection__Images=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1;QueueEndpoint=http://host.docker.internal:10001/devstoreaccount1;  # Azurite Connection Available Publically
+     - AzureWebJobsStorage=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azstorage:10000/devstoreaccount1;QueueEndpoint=http://azstorage:10001/devstoreaccount1; # Azurite Connection Available Publically
+     - StorageConnection__Images=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azstorage:10000/devstoreaccount1;QueueEndpoint=http://azstorage:10001/devstoreaccount1;  # Azurite Connection Available Publically
    depends_on:
      azstorage: # Ensure storage starts before the resize service
        condition: service_started # Ensure Azurite starts before the app


### PR DESCRIPTION
## Description

Addition of a devcontainer and vscode settings to permit development in vscode. Dependency services (sqlserver, azurite, image-resizer) can still be run in docker.

Fixes # (issue)
N/A

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with vscode running on Bluefin (linux)

- The infra/docker/docker-compose.yml file was modified to comment out the dertinfo-api service. All other services were left in place and launched using `docker compose up`
- User secrets were set for the dertinfo-api project. Hostname, `localhost`, was used to connect to the database.
- Launched the solution in vscode using the debug tools.
- Accessed http://localhost:8080/swagger/index.html to test that the API was running.

**Test Configuration**:
* Hardware: Laptop running Bluefin-dx.
* Toolchain: VSCode with devcontainer. Devcontainer configured to provide .NET 8.
* SDK: .NET 8

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules