### PR TITLE
Make usersecrets available in devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,12 @@
 		"dockerfile": "Dockerfile"
 	},
 	
+	"initializeCommand": "mkdir --parents ${HOME}/.microsoft/usersecrets",
+	
+	"mounts": [
+	    "source=${localEnv:HOME}/.microsoft/usersecrets,target=/home/vscode/.microsoft/usersecrets,type=bind,consistency=cached"
+	],
+
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},


### PR DESCRIPTION
## Description

Maps dotnet user secrets from the host into the devcontainer. This allows persisting of usersecrets between rebuilds/recreations of the dertinfo-api devcontainer, reducing the effort required for a developer to start using a new devcontainer.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Rebuilding the devcontainer and observing that usersecrets were automatically available to the dertinfo-api process that was built and run within the devcontainer.

Prior to this change it was necessary to apply the dotnet user secrets to each new devcontainer instance.

## NOT tested

I have not been able to confirm that these changes do not negatively impact use of GitHub Codespaces with the dertinfo-api repository since I do not have access to codespaces.

TODO: Please could someone test this PR with GitHub Codespaces.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules